### PR TITLE
add donation file of developer to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN \
   echo "*** Cleaning Up ***" && \
   rm /tmp/adguardhomesync.tar.gz
 
-COPY /root /
+COPY /root donate.txt /
 
 EXPOSE 8080
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -28,7 +28,7 @@ RUN \
   echo "*** Cleaning Up ***" && \
   rm /tmp/adguardhomesync.tar.gz
 
-COPY /root /
+COPY /root donate.txt /
 
 EXPOSE 8080
 

--- a/donate.txt
+++ b/donate.txt
@@ -1,0 +1,1 @@
+https://github.com/sponsors/bakito


### PR DESCRIPTION
As this image prints a donation url of linuxserver, also the developer donation url should be printed.

Adding the donate.txt will do just this.

Thank you
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-adguardhome-sync/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The developer sponsor link isalso present in the image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-baseimage-alpine/blob/master/root/etc/s6-overlay/s6-rc.d/init-adduser/run#L12